### PR TITLE
[ROWY-1731 ] [Chore] Removes prod cache when deployed

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "next build",
     "dev": "next",
-    "start": "next start",
-    "postbuild": "next-sitemap && echo 'Removing .next/cache to resolve Nextra caching bug' && rm -rf .next/cache"
+    "build": "next build",
+    "postbuild": "next-sitemap && echo 'Removing .next/cache to resolve Nextra caching bug' && rm -rf .next/cache",
+    "start": "next start"
   },
   "dependencies": {
     "@vercel/og": "^0.5.0",


### PR DESCRIPTION
Currently, Nextra has an issue with the deployment cache, when a PR or a commit is merged to the master the deployment cache must be manually purged to see merged updates on the site.

Fixes ROWY-1731 This PR fixes cache issues for prod.

Future - CI workflows are required to test build and deploy the site, to avoid site crashes. 