### PR TITLE
Update api-call-node.mdx

### DIFF
--- a/pages/core-nodes/api-call-node.mdx
+++ b/pages/core-nodes/api-call-node.mdx
@@ -56,14 +56,13 @@ in the code. This can be helpful for debugging and monitoring the behavior of yo
 
 ## Video
 
-{/* ISSUE with iframe */}
-{/* <iframe
+<iframe
     className="aspect-video w-full"
     src="https://www.youtube.com/embed/BhglVhy38_g?si=YOWZ60TzB0wGCUg0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;
-    allowfullscreen>
+    allowfullscreen"
     width="80%"
-/> */}
+/>
 
 That's it! You've successfully configured and tested an API call using the 'API Call' node in our platform. If you encounter
 any issues or have questions, feel free to reach out to our support team for assistance.


### PR DESCRIPTION
fixing typo - this has been tested locally with yarn dev and it is working as expected. The video is displayed correctly and it's not breaking the layout nor the deployment of the docs.